### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/gariasf/praxis/security/code-scanning/1](https://github.com/gariasf/praxis/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root so it applies to all jobs (including `check`) unless overridden later.  
For this workflow, the minimal required permission is:

- `contents: read`

This supports `actions/checkout@v4` and does not grant unnecessary write scopes.  
Edit `.github/workflows/ci.yml` by inserting `permissions:` after the `on:` triggers (before `env:` is a clean location).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration workflow security by implementing explicit GitHub Actions permissions configuration. The workflow now operates with restricted read-only access to repository contents, following security best practices and mitigating potential unauthorized access risks during automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->